### PR TITLE
style: add direction style in `Overlay.tsx` to keep ltr direction in …

### DIFF
--- a/.changeset/itchy-turtles-roll.md
+++ b/.changeset/itchy-turtles-roll.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/react-hydration-overlay": patch
+---
+
+Style: add `ltr` direction style in `Overlay.tsx`

--- a/packages/lib/src/Overlay.tsx
+++ b/packages/lib/src/Overlay.tsx
@@ -58,6 +58,7 @@ export function Overlay() {
         display: "flex",
         flexDirection: "column",
         fontFamily: "monospace",
+        direction: "ltr",
       }}
       onClick={hideModal}
     >


### PR DESCRIPTION
…rtl based projects

my project direction RTL and it was annoying whenever I had a hydration error I need to open inspect element and add direction style to the overlay so I added it by default to be  `ltr`