### PR TITLE
Switch component to use idiomatic function definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ First, wrap the root of your app in the `HydrationOverlay` component.
 ```tsx
 import { HydrationOverlay } from "@builder.io/react-hydration-overlay";
 
-const App = () => {
+export default function App() {
   return (
     <HydrationOverlay>
       <YourApp />
     </HydrationOverlay>
   );
-};
+}
 ```
 
 ### Plugin


### PR DESCRIPTION
The React docs and most official resources use the `function` keyword as their idiomatic style for components instead of constants with arrow function expressions