### PR TITLE
fix: remove event filename condition from initializer

### DIFF
--- a/.changeset/stale-phones-relate.md
+++ b/.changeset/stale-phones-relate.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/react-hydration-overlay": patch
+---
+
+Fix: remove filename checks (improves hydration error check)

--- a/packages/lib/src/hydration-overlay-initializer.js
+++ b/packages/lib/src/hydration-overlay-initializer.js
@@ -2,10 +2,9 @@ window.BUILDER_HYDRATION_OVERLAY = {};
 
 window.addEventListener("error", (event) => {
   const msg = event.message.toLowerCase();
-  const isReactDomError = event.filename.includes("react-dom");
   const isHydrationMsg = msg.includes("hydration") || msg.includes("hydrating");
 
-  if (isReactDomError && isHydrationMsg) {
+  if (isHydrationMsg) {
     window.BUILDER_HYDRATION_OVERLAY.ERROR = true;
     let appRootEl = document.querySelector(
       window.BUILDER_HYDRATION_OVERLAY.APP_ROOT_SELECTOR


### PR DESCRIPTION
Fixes https://github.com/BuilderIO/hydration-overlay/issues/36